### PR TITLE
Add custom directory selection via GUI, remove the env variable

### DIFF
--- a/osaurus/Controllers/ModelManager.swift
+++ b/osaurus/Controllers/ModelManager.swift
@@ -31,23 +31,10 @@ final class ModelManager: NSObject, ObservableObject {
     @Published var suggestedModels: [MLXModel] = ModelManager.curatedSuggestedModels
     
     // MARK: - Properties
-    nonisolated(unsafe) static var modelsDirectory: URL = {
-        // Allow override (useful for tests) via environment variable
-        if let overridePath = ProcessInfo.processInfo.environment["OSU_MODELS_DIR"], !overridePath.isEmpty {
-            let overrideURL = URL(fileURLWithPath: overridePath, isDirectory: true)
-            try? FileManager.default.createDirectory(at: overrideURL, withIntermediateDirectories: true)
-            return overrideURL
-        }
-
-        let documentsPath = FileManager.default.urls(for: .documentDirectory,
-                                                     in: .userDomainMask).first!
-        let modelsPath = documentsPath.appendingPathComponent("MLXModels")
-        
-        // Create directory if it doesn't exist
-        try? FileManager.default.createDirectory(at: modelsPath,
-                                                 withIntermediateDirectories: true)
-        return modelsPath
-    }()
+    /// Current models directory (uses DirectoryPickerService for user selection)
+    var modelsDirectory: URL {
+        return DirectoryPickerService.shared.effectiveModelsDirectory
+    }
     
     private var activeDownloadTasks: [String: Task<Void, Never>] = [:] // modelId -> Task
     private var downloadTokens: [String: UUID] = [:] // modelId -> token to gate progress/state updates

--- a/osaurus/Models/MLXModel.swift
+++ b/osaurus/Models/MLXModel.swift
@@ -27,7 +27,7 @@ struct MLXModel: Identifiable, Codable {
         size: Int64,
         downloadURL: String,
         requiredFiles: [String],
-        rootDirectory: URL = ModelManager.modelsDirectory
+        rootDirectory: URL? = nil
     ) {
         self.id = id
         self.name = name
@@ -35,7 +35,7 @@ struct MLXModel: Identifiable, Codable {
         self.size = size
         self.downloadURL = downloadURL
         self.requiredFiles = requiredFiles
-        self.rootDirectory = rootDirectory
+        self.rootDirectory = rootDirectory ?? DirectoryPickerService.shared.effectiveModelsDirectory
     }
     
     /// Human-readable size string

--- a/osaurus/Services/DirectoryPickerService.swift
+++ b/osaurus/Services/DirectoryPickerService.swift
@@ -1,0 +1,160 @@
+//
+//  DirectoryPickerService.swift
+//  osaurus
+//
+//  Created by Kamil Andrusz on 8/22/25.
+//
+
+import Foundation
+import SwiftUI
+
+/// Service for managing user-selected directory access with security-scoped bookmarks
+final class DirectoryPickerService: ObservableObject {
+    static let shared = DirectoryPickerService()
+    
+    @Published var selectedDirectory: URL?
+    @Published var hasValidDirectory: Bool = false
+    
+    private let bookmarkKey = "ModelDirectoryBookmark"
+    private var securityScopedResource: URL?
+    
+    // Thread-safe access to the effective directory
+    private let directoryQueue = DispatchQueue(label: "com.dinoki.osaurus.directory-access", attributes: .concurrent)
+    
+    private init() {
+        loadSavedDirectory()
+    }
+    
+    /// Load previously saved directory from security-scoped bookmark
+    private func loadSavedDirectory() {
+        guard let bookmarkData = UserDefaults.standard.data(forKey: bookmarkKey) else {
+            return
+        }
+        
+        do {
+            var isStale = false
+            let url = try URL(resolvingBookmarkData: bookmarkData,
+                            options: .withSecurityScope,
+                            relativeTo: nil,
+                            bookmarkDataIsStale: &isStale)
+            
+            if isStale {
+                // Bookmark is stale, need to recreate it
+                UserDefaults.standard.removeObject(forKey: bookmarkKey)
+                return
+            }
+            
+            // Start accessing the security-scoped resource
+            guard url.startAccessingSecurityScopedResource() else {
+                print("Failed to start accessing security-scoped resource")
+                return
+            }
+            
+            selectedDirectory = url
+            securityScopedResource = url
+            hasValidDirectory = true
+            
+        } catch {
+            print("Failed to resolve security-scoped bookmark: \(error)")
+            UserDefaults.standard.removeObject(forKey: bookmarkKey)
+        }
+    }
+    
+    /// Present directory picker and save selection
+    @MainActor func selectDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.title = "Choose Models Directory"
+        panel.message = "Select a directory where MLX models will be stored"
+        
+        guard panel.runModal() == .OK, let url = panel.url else {
+            return
+        }
+        
+        saveDirectory(url)
+    }
+    
+    /// Save directory selection from SwiftUI file picker
+    @MainActor func saveDirectoryFromFilePicker(_ url: URL) {
+        // For security-scoped resources from file picker, we need to start accessing first
+        guard url.startAccessingSecurityScopedResource() else {
+            print("Failed to access security-scoped resource from file picker")
+            return
+        }
+        
+        saveDirectory(url)
+    }
+    
+    /// Save directory selection with security-scoped bookmark
+    private func saveDirectory(_ url: URL) {
+        // Stop accessing previous resource
+        securityScopedResource?.stopAccessingSecurityScopedResource()
+        
+        do {
+            // Create security-scoped bookmark
+            let bookmarkData = try url.bookmarkData(options: .withSecurityScope,
+                                                  includingResourceValuesForKeys: nil,
+                                                  relativeTo: nil)
+            
+            // Save bookmark to UserDefaults
+            UserDefaults.standard.set(bookmarkData, forKey: bookmarkKey)
+            
+            // Start accessing the new resource
+            guard url.startAccessingSecurityScopedResource() else {
+                print("Failed to start accessing newly selected directory")
+                return
+            }
+            
+            selectedDirectory = url
+            securityScopedResource = url
+            hasValidDirectory = true
+            
+        } catch {
+            print("Failed to create security-scoped bookmark: \(error)")
+        }
+    }
+    
+    /// Get the effective models directory (user-selected or default)
+    /// This method is thread-safe for use from any context
+    var effectiveModelsDirectory: URL {
+        return directoryQueue.sync {
+            // Check UserDefaults directly for the bookmark
+            if let bookmarkData = UserDefaults.standard.data(forKey: bookmarkKey) {
+                do {
+                    var isStale = false
+                    let url = try URL(resolvingBookmarkData: bookmarkData,
+                                    options: .withSecurityScope,
+                                    relativeTo: nil,
+                                    bookmarkDataIsStale: &isStale)
+                    
+                    if !isStale {
+                        return url
+                    }
+                } catch {
+                    // Bookmark invalid, fall through to default
+                }
+            }
+            
+            // Fall back to default sandbox-safe location
+            let documentsPath = FileManager.default.urls(for: .documentDirectory,
+                                                         in: .userDomainMask).first!
+            return documentsPath.appendingPathComponent("MLXModels")
+        }
+    }
+    
+    /// Reset directory selection
+    @MainActor func resetDirectory() {
+        securityScopedResource?.stopAccessingSecurityScopedResource()
+        securityScopedResource = nil
+        selectedDirectory = nil
+        hasValidDirectory = false
+        UserDefaults.standard.removeObject(forKey: bookmarkKey)
+    }
+    
+    deinit {
+        securityScopedResource?.stopAccessingSecurityScopedResource()
+    }
+}

--- a/osaurus/Services/MLXService.swift
+++ b/osaurus/Services/MLXService.swift
@@ -273,7 +273,7 @@ class MLXService {
     /// Returns pairs of (name, id) where id is "org/repo" and name is the repo lowercased.
     nonisolated private static func scanDiskForModels() -> [(name: String, id: String)] {
         let fm = FileManager.default
-        let root = ModelManager.modelsDirectory
+        let root = DirectoryPickerService.shared.effectiveModelsDirectory
         guard let topLevel = try? fm.contentsOfDirectory(at: root, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]) else {
             return []
         }
@@ -328,7 +328,7 @@ class MLXService {
     /// Locate local directory for a given model id ("org/repo") if files exist
     nonisolated private static func findLocalDirectory(forModelId id: String) -> URL? {
         let parts = id.split(separator: "/").map(String.init)
-        let url: URL = parts.reduce(ModelManager.modelsDirectory) { partial, component in
+        let url: URL = parts.reduce(DirectoryPickerService.shared.effectiveModelsDirectory) { partial, component in
             partial.appendingPathComponent(component, isDirectory: true)
         }
         let fm = FileManager.default

--- a/osaurus/Views/ContentView.swift
+++ b/osaurus/Views/ContentView.swift
@@ -336,8 +336,17 @@ struct ConfigurationView: View {
                 Text("Enter a port number between 1 and 65535")
                     .font(.system(size: 11))
                     .foregroundColor(theme.tertiaryText)
+                
+                // Models directory configuration (always visible)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Models Directory")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundColor(theme.secondaryText)
+                    
+                    DirectoryPickerView()
+                }
             }
-            
+
             Button(action: {
                 showAdvancedSettings.toggle()
             }) {

--- a/osaurus/Views/DirectoryPickerView.swift
+++ b/osaurus/Views/DirectoryPickerView.swift
@@ -1,0 +1,127 @@
+//
+//  DirectoryPickerView.swift
+//  osaurus
+//
+//  Created by Kamil Andrusz on 8/22/25.
+//
+
+import SwiftUI
+
+/// View for selecting and managing the models directory
+struct DirectoryPickerView: View {
+    @StateObject private var directoryPicker = DirectoryPickerService.shared
+    @Environment(\.theme) private var theme
+    @State private var showFilePicker = false
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Directory display field with theme styling
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(directoryDisplayText)
+                        .font(.system(size: 13, weight: .medium, design: .monospaced))
+                        .foregroundColor(theme.primaryText)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    
+                    if directoryPicker.hasValidDirectory {
+                        Text("Custom directory selected")
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.secondaryText)
+                    } else {
+                        Text("Using default location")
+                            .font(.system(size: 11))
+                            .foregroundColor(theme.tertiaryText)
+                    }
+                }
+                
+                Spacer()
+                
+                // Action buttons with consistent styling
+                HStack(spacing: 6) {
+                    Button(action: {
+                        showFilePicker = true
+                    }) {
+                        Image(systemName: "folder.badge.gearshape")
+                            .font(.system(size: 12))
+                            .foregroundColor(theme.primaryText)
+                            .frame(width: 24, height: 24)
+                            .background(
+                                Circle()
+                                    .fill(theme.buttonBackground)
+                                    .overlay(
+                                        Circle()
+                                            .stroke(theme.buttonBorder, lineWidth: 1)
+                                    )
+                            )
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                    .help("Select custom directory")
+                    
+                    if directoryPicker.hasValidDirectory {
+                        Button(action: {
+                            directoryPicker.resetDirectory()
+                        }) {
+                            Image(systemName: "arrow.counterclockwise")
+                                .font(.system(size: 12))
+                                .foregroundColor(theme.primaryText)
+                                .frame(width: 24, height: 24)
+                                .background(
+                                    Circle()
+                                        .fill(theme.buttonBackground)
+                                        .overlay(
+                                            Circle()
+                                                .stroke(theme.buttonBorder, lineWidth: 1)
+                                        )
+                                )
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        .help("Reset to default directory")
+                    }
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(theme.inputBackground)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(theme.inputBorder, lineWidth: 1)
+                    )
+            )
+            
+            // Help text
+            Text("Models will be organized in subfolders by repository name")
+                .font(.system(size: 11))
+                .foregroundColor(theme.tertiaryText)
+        }
+        .fileImporter(
+            isPresented: $showFilePicker,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case .success(let urls):
+                if let url = urls.first {
+                    directoryPicker.saveDirectoryFromFilePicker(url)
+                }
+            case .failure(let error):
+                print("Directory selection failed: \(error)")
+            }
+        }
+    }
+    
+    private var directoryDisplayText: String {
+        if directoryPicker.hasValidDirectory,
+           let selectedDirectory = directoryPicker.selectedDirectory {
+            return selectedDirectory.path
+        } else {
+            return "~/Documents/MLXModels"
+        }
+    }
+}
+
+#Preview {
+    DirectoryPickerView()
+}

--- a/osaurus/osaurus.entitlements
+++ b/osaurus/osaurus.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>


### PR DESCRIPTION
## Summary

This pull request introduces user-selectable model directory support for MLX models, allowing users to choose and persist a custom directory for model storage using a new `DirectoryPickerService`. The implementation includes a SwiftUI view for directory selection and updates all model directory references to use the new service. The app's entitlements are also updated to support read/write access to user-selected directories.

**User-selectable models directory support:**

* Added `DirectoryPickerService`, a singleton service to manage user-selected directories with security-scoped bookmarks, including methods for loading, saving, and resetting directory access. All directory access is now routed through this service for thread safety and sandbox compliance.
* Introduced `DirectoryPickerView`, a SwiftUI component for selecting and resetting the models directory, with UI integration in `ConfigurationView`. [[1]](diffhunk://#diff-7a8460a2fb2ace5af3c8258dbd45e3d2575a7e496f06c1ac07d0a3a8eff3d22cR1-R127) [[2]](diffhunk://#diff-7a42bc496ba2c08a66573c23b66335f9e405ffe0b5cf97b162095ef419f7682eR339-R347)

**Refactoring and integration:**

* Replaced all direct references to the static `ModelManager.modelsDirectory` with calls to `DirectoryPickerService.shared.effectiveModelsDirectory` across the codebase, including in `ModelManager`, `MLXModel`, and `MLXService`. This ensures all model file operations respect the user-selected directory. [[1]](diffhunk://#diff-38d6df49a35feffb4a27dfafdf1338ca987f7a971287a4648d4d9b6f001f2fc7L34-R37) [[2]](diffhunk://#diff-71821c048757108bc888d67c97dad64e4706d134155d0a3e435c53928137e0baL30-R38) [[3]](diffhunk://#diff-cfbb2601dd5ea9bfc1179649fbaae579e7b877418d523e6bfee035d4bec38770L276-R276) [[4]](diffhunk://#diff-cfbb2601dd5ea9bfc1179649fbaae579e7b877418d523e6bfee035d4bec38770L331-R331)

**App sandboxing and permissions:**

* Updated the app's entitlements to request `com.apple.security.files.user-selected.read-write` instead of read-only, enabling the app to write to user-selected directories.

## Changes

- [x] Behavior change
- [x ] UI change (screenshots below)
- [ ] Refactor / chore
- [ ] Tests
- [ ] Docs

## Test Plan

Steps to verify locally (commands, screenshots, recordings). Include model used.

## Screenshots

### Before
<img width="772" height="522" alt="image" src="https://github.com/user-attachments/assets/1e2c9e38-4e3c-47ac-acaa-9b82c9db7894" />

### After
<img width="772" height="728" alt="image" src="https://github.com/user-attachments/assets/5fb65fb4-7710-41c3-a0cd-025924ab97c8" />


## Checklist

- [x] I have read `CONTRIBUTING.md`
- [ ] I added/updated tests where reasonable
- [ ] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
