### PR TITLE
Add Interop API endpoints, NDJSON streaming, request logging, and route normalization

### DIFF
--- a/osaurus/Models/OpenAIAPI.swift
+++ b/osaurus/Models/OpenAIAPI.swift
@@ -90,6 +90,70 @@ struct ChatCompletionResponse: Codable {
     let system_fingerprint: String?
 }
 
+// MARK: - Interop API Structures (Ollama-compatible)
+
+struct InteropTagsResponse: Codable {
+    let models: [InteropModelTag]
+}
+
+struct InteropModelTag: Codable {
+    let name: String
+    let model: String
+    let modified_at: String
+    let size: Int
+    let digest: String
+    let details: InteropModelDetails
+}
+
+struct InteropModelDetails: Codable {
+    let parent_model: String
+    let format: String
+    let family: String
+    let families: [String]
+    let parameter_size: String
+    let quantization_level: String
+}
+
+struct InteropShowRequest: Codable {
+    let model: String
+    let verbose: Bool?
+}
+
+struct InteropShowResponse: Codable {
+    let modelfile: String
+    let parameters: String
+    let template: String
+    let details: InteropModelDetails
+    let model_info: [String: JSONValue]?
+    let capabilities: [String]
+}
+
+// MARK: - Ollama Chat / Generate
+
+struct InteropChatMessage: Codable {
+    let role: String
+    let content: String
+}
+
+struct InteropChatRequest: Codable {
+    let model: String
+    let messages: [InteropChatMessage]
+    let stream: Bool?
+}
+
+struct InteropGenerateRequest: Codable {
+    let model: String
+    let prompt: String
+    let stream: Bool?
+}
+
+struct InteropChatResponse: Codable {
+    let model: String
+    let created_at: String
+    let message: InteropChatMessage
+    let done: Bool
+}
+
 // MARK: - Streaming Response Structures
 
 /// Delta content for streaming

--- a/osaurus/Networking/Router.swift
+++ b/osaurus/Networking/Router.swift
@@ -33,7 +33,11 @@ public struct Router {
     ///   - body: Request body data
     /// - Returns: Tuple containing status, headers, and response body
     public func route(method: String, path: String, body: Data = Data()) -> (status: HTTPResponseStatus, headers: [(String, String)], body: String) {
-        switch (method, path) {
+        // Normalize provider prefixes so we support /, /v1, /api, /v1/api
+        let p = normalize(path)
+        // Many clients probe with HEAD; always OK fast
+        if method == "HEAD" { return headOkEndpoint() }
+        switch (method, p) {
         case ("GET", "/health"):
             return healthEndpoint()
             
@@ -42,15 +46,23 @@ public struct Router {
             
         case ("GET", "/models"):
             return modelsEndpoint()
-
-        case ("GET", "/v1/models"):
-            return modelsEndpoint()
             
+        case ("GET", "/tags"):
+            return tagsEndpoint()
+            
+            
+        case ("POST", "/show"):
+            return showEndpoint(body: body)
+
         case ("POST", "/chat/completions"):
             return chatCompletionsEndpoint(body: body, context: context, handler: handler)
 
-        case ("POST", "/v1/chat/completions"):
-            return chatCompletionsEndpoint(body: body, context: context, handler: handler)
+        // Ollama chat/generate compatibility (normalized from /api/...)
+        case ("POST", "/chat"):
+            return interopChatEndpoint(body: body, context: context, handler: handler)
+            
+        case ("POST", "/generate"):
+            return interopGenerateEndpoint(body: body, context: context, handler: handler)
             
         default:
             return notFoundEndpoint()
@@ -59,7 +71,9 @@ public struct Router {
 
     /// Overload that accepts a ByteBuffer body to enable zero-copy decoding
     public func route(method: String, path: String, bodyBuffer: ByteBuffer) -> (status: HTTPResponseStatus, headers: [(String, String)], body: String) {
-        switch (method, path) {
+        let p = normalize(path)
+        if method == "HEAD" { return headOkEndpoint() }
+        switch (method, p) {
         case ("GET", "/health"):
             return healthEndpoint()
         
@@ -68,15 +82,22 @@ public struct Router {
         
         case ("GET", "/models"):
             return modelsEndpoint()
-
-        case ("GET", "/v1/models"):
-            return modelsEndpoint()
             
+        case ("GET", "/tags"):
+            return tagsEndpoint()
+            
+        case ("POST", "/show"):
+            return showEndpoint(bodyBuffer: bodyBuffer)
+
         case ("POST", "/chat/completions"):
             return chatCompletionsEndpoint(bodyBuffer: bodyBuffer, context: context, handler: handler)
 
-        case ("POST", "/v1/chat/completions"):
-            return chatCompletionsEndpoint(bodyBuffer: bodyBuffer, context: context, handler: handler)
+        // Ollama chat/generate compatibility (normalized from /api/...)
+        case ("POST", "/chat"):
+            return interopChatEndpoint(bodyBuffer: bodyBuffer, context: context, handler: handler)
+            
+        case ("POST", "/generate"):
+            return interopGenerateEndpoint(bodyBuffer: bodyBuffer, context: context, handler: handler)
             
         default:
             return notFoundEndpoint()
@@ -100,6 +121,10 @@ public struct Router {
         return (.notFound, [("Content-Type", "text/plain; charset=utf-8")], "Not Found")
     }
     
+    private func headOkEndpoint() -> (HTTPResponseStatus, [(String, String)], String) {
+        return (.noContent, [("Content-Type", "text/plain; charset=utf-8")], "")
+    }
+    
     private func modelsEndpoint() -> (HTTPResponseStatus, [(String, String)], String) {
         let models = MLXService.getAvailableModels().map { modelName in
             OpenAIModel(from: modelName)
@@ -111,6 +136,130 @@ public struct Router {
             return (.ok, [("Content-Type", "application/json; charset=utf-8")], json)
         }
         return errorResponse(message: "Failed to encode models", statusCode: .internalServerError)
+    }
+
+    // MARK: - Interop-compatible endpoints (Ollama-like)
+    
+    private func tagsEndpoint() -> (HTTPResponseStatus, [(String, String)], String) {
+        let modelNames = MLXService.getAvailableModels()
+        let now = Date().ISO8601Format()
+        let tags: [InteropModelTag] = modelNames.map { name in
+            InteropModelTag(
+                name: "\(name):latest",
+                model: "\(name):latest",
+                modified_at: now,
+                size: 0,
+                digest: "",
+                details: InteropModelDetails(
+                    parent_model: "",
+                    format: "safetensors",
+                    family: "unknown",
+                    families: ["unknown"],
+                    parameter_size: "",
+                    quantization_level: ""
+                )
+            )
+        }
+        let response = InteropTagsResponse(models: tags)
+        if let json = encodeJSONString(response) {
+            return (.ok, [("Content-Type", "application/json; charset=utf-8")], json)
+        }
+        return errorResponse(message: "Failed to encode tags", statusCode: .internalServerError)
+    }
+
+    private func showEndpoint(body: Data) -> (HTTPResponseStatus, [(String, String)], String) {
+        let decoder = Self.makeJSONDecoder()
+        guard let req = try? decoder.decode(InteropShowRequest.self, from: body) else {
+            return errorResponse(message: "Invalid request format", statusCode: .badRequest)
+        }
+        return buildShowResponse(for: req)
+    }
+
+    private func showEndpoint(bodyBuffer: ByteBuffer) -> (HTTPResponseStatus, [(String, String)], String) {
+        let decoder = Self.makeJSONDecoder()
+        guard let req = try? decoder.decode(InteropShowRequest.self, from: bodyBuffer) else {
+            return errorResponse(message: "Invalid request format", statusCode: .badRequest)
+        }
+        return buildShowResponse(for: req)
+    }
+    
+    private func buildShowResponse(for req: InteropShowRequest) -> (HTTPResponseStatus, [(String, String)], String) {
+        // Normalize model name (strip tag like :latest)
+        let base = req.model.split(separator: ":").first.map(String.init) ?? req.model
+        let available = MLXService.getAvailableModels()
+        guard available.contains(where: { $0 == base }) else {
+            return errorResponse(message: "Model not found: \(req.model)", statusCode: .notFound)
+        }
+
+        let details = InteropModelDetails(
+            parent_model: "",
+            format: "safetensors",
+            family: "unknown",
+            families: ["unknown"],
+            parameter_size: "",
+            quantization_level: ""
+        )
+        let resp = InteropShowResponse(
+            modelfile: "",
+            parameters: "",
+            template: "",
+            details: details,
+            model_info: nil,
+            capabilities: ["completion"]
+        )
+        if let json = encodeJSONString(resp) {
+            return (.ok, [("Content-Type", "application/json; charset=utf-8")], json)
+        }
+        return errorResponse(message: "Failed to encode show response", statusCode: .internalServerError)
+    }
+
+    // MARK: - Compat chat/generate endpoints
+    private func interopChatEndpoint(body: Data, context: ChannelHandlerContext?, handler: HTTPHandler?) -> (HTTPResponseStatus, [(String, String)], String) {
+        let decoder = Self.makeJSONDecoder()
+        guard let req = try? decoder.decode(InteropChatRequest.self, from: body) else {
+            return errorResponse(message: "Invalid request format", statusCode: .badRequest)
+        }
+        return handleInteropChat(req: req, context: context, handler: handler)
+    }
+    private func interopChatEndpoint(bodyBuffer: ByteBuffer, context: ChannelHandlerContext?, handler: HTTPHandler?) -> (HTTPResponseStatus, [(String, String)], String) {
+        let decoder = Self.makeJSONDecoder()
+        guard let req = try? decoder.decode(InteropChatRequest.self, from: bodyBuffer) else {
+            return errorResponse(message: "Invalid request format", statusCode: .badRequest)
+        }
+        return handleInteropChat(req: req, context: context, handler: handler)
+    }
+    private func handleInteropChat(req: InteropChatRequest, context: ChannelHandlerContext?, handler: HTTPHandler?) -> (HTTPResponseStatus, [(String, String)], String) {
+        guard let context = context, let _ = handler else {
+            return errorResponse(message: "Server configuration error", statusCode: .internalServerError)
+        }
+        // Use Interop NDJSON handler
+        Task.detached(priority: .userInitiated) {
+            await AsyncHTTPHandler.shared.handleInteropChat(request: req, context: context)
+        }
+        return (.ok, [], "")
+    }
+    private func interopGenerateEndpoint(body: Data, context: ChannelHandlerContext?, handler: HTTPHandler?) -> (HTTPResponseStatus, [(String, String)], String) {
+        let decoder = Self.makeJSONDecoder()
+        guard let req = try? decoder.decode(InteropGenerateRequest.self, from: body) else {
+            return errorResponse(message: "Invalid request format", statusCode: .badRequest)
+        }
+        return handleInteropGenerate(req: req, context: context, handler: handler)
+    }
+    private func interopGenerateEndpoint(bodyBuffer: ByteBuffer, context: ChannelHandlerContext?, handler: HTTPHandler?) -> (HTTPResponseStatus, [(String, String)], String) {
+        let decoder = Self.makeJSONDecoder()
+        guard let req = try? decoder.decode(InteropGenerateRequest.self, from: bodyBuffer) else {
+            return errorResponse(message: "Invalid request format", statusCode: .badRequest)
+        }
+        return handleInteropGenerate(req: req, context: context, handler: handler)
+    }
+    private func handleInteropGenerate(req: InteropGenerateRequest, context: ChannelHandlerContext?, handler: HTTPHandler?) -> (HTTPResponseStatus, [(String, String)], String) {
+        guard let context = context, let _ = handler else {
+            return errorResponse(message: "Server configuration error", statusCode: .internalServerError)
+        }
+        Task.detached(priority: .userInitiated) {
+            await AsyncHTTPHandler.shared.handleInteropGenerate(request: req, context: context)
+        }
+        return (.ok, [], "")
     }
     
     private func chatCompletionsEndpoint(body: Data, context: ChannelHandlerContext?, handler: HTTPHandler?) -> (HTTPResponseStatus, [(String, String)], String) {
@@ -184,5 +333,23 @@ public struct Router {
         } catch {
             return nil
         }
+    }
+    
+    // Normalize common provider prefixes so we cover /, /v1, /api, /v1/api
+    private func normalize(_ path: String) -> String {
+        func stripPrefix(_ prefix: String, from s: String) -> String? {
+            if s == prefix { return "/" }
+            if s.hasPrefix(prefix + "/") {
+                let idx = s.index(s.startIndex, offsetBy: prefix.count)
+                let rest = String(s[idx...])
+                return rest.isEmpty ? "/" : rest
+            }
+            return nil
+        }
+        // Try in most-specific order
+        if let r = stripPrefix("/v1/api", from: path) { return r }
+        if let r = stripPrefix("/api", from: path) { return r }
+        if let r = stripPrefix("/v1", from: path) { return r }
+        return path
     }
 }


### PR DESCRIPTION
## Summary

* Implement `GET /tags`, `POST /show` (Interop format), plus `/api/*`, `/v1/*`, `/v1/api/*` variants
* Add `POST /chat` and `POST /generate` Interop endpoints with NDJSON streaming
* Normalize paths to handle `/`, `/v1`, `/api`, `/v1/api` prefixes uniformly
* Return 204 for `HEAD` probes (e.g., `/v1`, `/v1/`)

## Changes

- [x] Behavior change
- [ ] UI change (screenshots below)
- [x] Refactor / chore
- [ ] Tests
- [ ] Docs

## Test Plan

* Run Osaurus
* Configure Enchanted with the following URL `http://127.0.0.1:8080/v1`
* Models should show
* Chat should work

## Screenshots

<img width="493" height="706" alt="Screenshot 2025-08-28 at 8 12 52 PM" src="https://github.com/user-attachments/assets/8c8d11ef-dce8-4c99-aa58-40d8eb8579f0" />

<img width="896" height="512" alt="Screenshot 2025-08-28 at 8 13 04 PM" src="https://github.com/user-attachments/assets/63d9cf7d-c501-4ea2-b973-390d5810777f" />



## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
