### PR TITLE
added prefix cache for performance

### DIFF
--- a/osaurus/Services/MLXService.swift
+++ b/osaurus/Services/MLXService.swift
@@ -569,7 +569,6 @@ final class MLXService: @unchecked Sendable {
     }
 
     /// Generate event stream from MLX that can include both text chunks and tool call events.
-    /// This mirrors MLX Swift examples' event-based streaming and lets callers react to tool calls directly.
     func generateEvents(
         messages: [Message],
         model: LMModel,
@@ -898,8 +897,6 @@ extension MLXService {
         let dir = promptCacheDirectory(modelId: modelId)
         return dir.appendingPathComponent("prefix-\(hash).safetensors", isDirectory: false)
     }
-
-    // Legacy migration helpers removed (all caches already migrated outside model dir)
 
     /// Ensure the parent directory exists for a file URL
     private static func ensureParentDirectoryExists(for url: URL) throws {


### PR DESCRIPTION
## Summary

In order to speed up the TTFT, implemented a prefix cache and passing it into the MLX library. Currently, `ChatSession` is not suitable for use, mainly because Osaurus' API is stateless. Implementing our own caching system should help with the initial TTFT.

## Changes

- [ ] Behavior change
- [ ] UI change (screenshots below)
- [x] Refactor / chore
- [x] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
