### PR TITLE
huge performance gains with transformers fix

### DIFF
--- a/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/osaurus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift-examples",
       "state" : {
-        "revision" : "24219cd54bdef95f4693f8743264e3d53ffdc12a",
-        "version" : "2.25.6"
+        "revision" : "dddb0b3871390dd9dea8e7ff2c347cf7e74cec9d",
+        "version" : "2.25.7"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "e5bf0627bd134cf8ddc407cda403ae84207af959",
-        "version" : "0.1.22"
+        "revision" : "ed54f3c9589d6cdc6fc2bb810e4809b0735fee01",
+        "version" : "0.1.23"
       }
     }
   ],


### PR DESCRIPTION
## Summary

I found latency issues with `generateEvents` function, and found out that `swift-transformers` package needed some optimization. 

PR -> https://github.com/huggingface/swift-transformers/pull/218
PR -> https://github.com/ml-explore/mlx-swift-examples/issues/380

The results before:

```
Running warm-up: 3 server(s), 2 prompt(s), 1 iteration(s) each, concurrency=1 (excluded from results)...
Running benchmark against 3 server(s), 2 prompt(s), 10 iteration(s) each, concurrency=1, system_prompt=ON...

Summary:
- osaurus | llama-3.2-3b-instruct-4bit:
  success_rate=100.0%  ttft_avg=222.5ms  ttft_p50=214.7ms  ttft_p95=248.3ms  total_avg=1272.1ms  p50=1190.7ms  p95=2062.5ms  chars/s=480.1  bytes/s=480.1
- ollama | llama3.2:
  success_rate=100.0%  ttft_avg=58.3ms  ttft_p50=52.0ms  ttft_p95=90.5ms  total_avg=1632.0ms  p50=1485.5ms  p95=3009.4ms  chars/s=438.9  bytes/s=438.9
- lmstudio | llama-3.2-3b-instruct:
  success_rate=100.0%  ttft_avg=55.5ms  ttft_p50=50.5ms  ttft_p95=94.9ms  total_avg=1171.7ms  p50=1131.3ms  p95=2092.3ms  chars/s=623.0  bytes/s=623.0
```

The results after 🤯:

```
Running warm-up: 3 server(s), 2 prompt(s), 1 iteration(s) each, concurrency=1 (excluded from results)...
Running benchmark against 3 server(s), 2 prompt(s), 10 iteration(s) each, concurrency=1, system_prompt=ON...

Summary:
- osaurus | llama-3.2-3b-instruct-4bit:
  success_rate=100.0%  ttft_avg=84.2ms  ttft_p50=82.4ms  ttft_p95=87.4ms  total_avg=1330.3ms  p50=1192.0ms  p95=2433.8ms  chars/s=560.6  bytes/s=560.6
- ollama | llama3.2:
  success_rate=100.0%  ttft_avg=59.7ms  ttft_p50=52.0ms  ttft_p95=93.6ms  total_avg=1690.4ms  p50=1453.2ms  p95=3222.2ms  chars/s=439.4  bytes/s=439.4
- lmstudio | llama-3.2-3b-instruct:
  success_rate=100.0%  ttft_avg=55.5ms  ttft_p50=50.7ms  ttft_p95=92.8ms  total_avg=1143.6ms  p50=1092.0ms  p95=2087.0ms  chars/s=613.2  bytes/s=613.2
  ```

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+
