### PR TITLE
tools streaming optimizations

### DIFF
--- a/osaurus/Networking/AsyncHTTPHandler.swift
+++ b/osaurus/Networking/AsyncHTTPHandler.swift
@@ -338,7 +338,8 @@ class AsyncHTTPHandler {
                 // Flush any pending content and break
                 executeOnLoop(loop) {
                   if pendingBuffer.readableBytes > 0 {
-                    let content = pendingBuffer.readString(length: pendingBuffer.readableBytes) ?? ""
+                    let content =
+                      pendingBuffer.readString(length: pendingBuffer.readableBytes) ?? ""
                     writerBox.value.writeContent(
                       content, model: requestModel, responseId: responseId, created: created,
                       context: ctxBox.value)


### PR DESCRIPTION
## Summary

Related to #24, added a short “probe then stream” flow when tools are enabled: buffer only the first few tokens/bytes to detect a tool call.

## Changes

- [ ] Behavior change
- [ ] UI change (screenshots below)
- [x] Refactor / chore
- [x] Tests
- [ ] Docs

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] I added/updated tests where reasonable
- [x] I updated docs/README as needed
- [x] I verified build on macOS with Xcode 16.4+